### PR TITLE
Modified: Support single object response

### DIFF
--- a/json-form-load-binder/src/main/java/org/joget/JsonFormLoadBinder.java
+++ b/json-form-load-binder/src/main/java/org/joget/JsonFormLoadBinder.java
@@ -124,7 +124,7 @@ public class JsonFormLoadBinder extends FormBinder implements FormLoadBinder, Fo
                             Map mapping = (HashMap) o;
                             String attribute = mapping.get("attribute").toString();
                             String fieldId = mapping.get("fieldId").toString();
-                            String value = (String) jsonObject.get(attribute);
+                            String value = (String) getObjectFromMap(attribute, jsonObject);
                             row.setProperty(fieldId, value);
                         }
                     }
@@ -250,11 +250,19 @@ public class JsonFormLoadBinder extends FormBinder implements FormLoadBinder, Fo
             if (key.contains(".")) {
                 String subKey = key.substring(key.indexOf(".") + 1);
                 key = key.substring(0, key.indexOf("."));
+                
+                Object tempObj = getObjectFromMap(key, object);
+                Map tempObjectMap = null;
+                
+                if (tempObj instanceof Object[]) {
+                    Object [] tempObjArray = (Object[]) tempObj;
+                    tempObjectMap = (Map) tempObjArray[0];
+                } else if (tempObj instanceof Map) {
+                    tempObjectMap = (Map) tempObj;
+                }
 
-                Map tempObject = (Map) getObjectFromMap(key, object);
-
-                if (tempObject != null) {
-                    return getObjectFromMap(subKey, tempObject);
+                if (tempObjectMap != null) {
+                    return getObjectFromMap(subKey, tempObjectMap);
                 }
             } else if ((key.contains("[")) && (key.contains("]"))) {
                 String tempKey = key.substring(0, key.indexOf("["));

--- a/json-form-load-binder/src/main/java/org/joget/JsonFormLoadBinder.java
+++ b/json-form-load-binder/src/main/java/org/joget/JsonFormLoadBinder.java
@@ -125,7 +125,9 @@ public class JsonFormLoadBinder extends FormBinder implements FormLoadBinder, Fo
                             String attribute = mapping.get("attribute").toString();
                             String fieldId = mapping.get("fieldId").toString();
                             String value = (String) getObjectFromMap(attribute, jsonObject);
-                            row.setProperty(fieldId, value);
+                            if (value != null && !value.isBlank()) {
+                                row.setProperty(fieldId, value);
+                            }
                         }
                     }
                     
@@ -256,6 +258,9 @@ public class JsonFormLoadBinder extends FormBinder implements FormLoadBinder, Fo
                 
                 if (tempObj instanceof Object[]) {
                     Object [] tempObjArray = (Object[]) tempObj;
+                    if (tempObjArray.length == 0) {
+                        return null;
+                    }
                     tempObjectMap = (Map) tempObjArray[0];
                 } else if (tempObj instanceof Map) {
                     tempObjectMap = (Map) tempObj;

--- a/json-form-load-binder/src/main/java/org/joget/JsonFormLoadBinder.java
+++ b/json-form-load-binder/src/main/java/org/joget/JsonFormLoadBinder.java
@@ -114,7 +114,22 @@ public class JsonFormLoadBinder extends FormBinder implements FormLoadBinder, Fo
                         }
                     }
                 } else {
-                    LogUtil.info(getClass().getName(), "Invalid Base Object Name.");
+//                    LogUtil.info(getClass().getName(), "Invalid Base Object Name.");
+
+                    //Support single object responses
+                    FormRow row = new FormRow();
+
+                    if (mappings != null && mappings.length > 0) {
+                        for (Object o : mappings) {
+                            Map mapping = (HashMap) o;
+                            String attribute = mapping.get("attribute").toString();
+                            String fieldId = mapping.get("fieldId").toString();
+                            String value = (String) jsonObject.get(attribute);
+                            row.setProperty(fieldId, value);
+                        }
+                    }
+                    
+                    results.add(row);
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
@hugoatjoget
This is to support single object response that some APIs can return.
Example:
```
{
  "id": "abc",
  "name": "abcd",
  "symbol": "ABCD",
  "createdAt": 1490249363000
}
```